### PR TITLE
docs: 修复按需引入组件路径的问题

### DIFF
--- a/packages/taro-ui-docs/markdown/quickstart.md
+++ b/packages/taro-ui-docs/markdown/quickstart.md
@@ -74,8 +74,8 @@ npm i babel-plugin-import -D
       'import',
       {
         libraryName: 'taro-ui',
-        customName: name => `taro-ui/lib/components/${name.split('-')[1]}`,
-        customStyleName: name => `taro-ui/dist/style/components/${name.split('-')[1]}.scss`
+        customName: name => `taro-ui/lib/components/${name.slice(3)}`,
+        customStyleName: name => `taro-ui/dist/style/components/${name.slice(3)}.scss`
       },
       'taro-ui'
     ]


### PR DESCRIPTION
`at-search-bar` 路径会被识别成 `search` 而不是 `search-bar`